### PR TITLE
remove static qualifiers on BL_* constants

### DIFF
--- a/include/bliss.h
+++ b/include/bliss.h
@@ -16,11 +16,11 @@
     #define av_frame_free avcodec_free_frame
 #endif
 
-static const int BL_LOUD = 0;
-static const int BL_CALM = 1;
-static const int BL_UNKNOWN = 2;
-static const int BL_UNEXPECTED = -2;
-static const int BL_OK = 0;
+#define BL_LOUD 0
+#define BL_CALM 1
+#define BL_UNKNOWN 2
+#define BL_UNEXPECTED -2
+#define BL_OK 0
 
 struct force_vector_s {
     float tempo;


### PR DESCRIPTION
BL_{LOUD, CALM, UNKNOWN, UNEXPECTED, OK} have static qualifiers which prevent library users from using these constants. This removes these qualifiers.