### PR TITLE
tests/analyse: fix incorrect expected ML test values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ addons:
             - libswresample-dev
             - libfftw3-dev
 script:
-    - cmake . && cmake --build .
-    - make test
+    - mkdir build && cd build && cmake .. && cmake --build .
+    - make CTEST_OUTPUT_ON_FAILURE=1 test
 compiler:
     - gcc
     - clang

--- a/tests/test_analyze.c
+++ b/tests/test_analyze.c
@@ -31,12 +31,12 @@ void test_analyze(void) {
     struct bl_song song;
     bl_analyze("../audio/song.mp3", &song);
 
-    assert_floateq(song.force, -1.284405);
+    assert_floateq(song.force, -1.349859);
 
-    assert_floateq(song.force_vector.tempo, -0.378798);
-    assert_floateq(song.force_vector.amplitude, 0.262785);
-    assert_floateq(song.force_vector.frequency, -1.547190);
-    assert_floateq(song.force_vector.attack, -1.207954);
+    assert_floateq(song.force_vector.tempo, -0.110247);
+    assert_floateq(song.force_vector.amplitude, 0.197553);
+    assert_floateq(song.force_vector.frequency, -1.547412);
+    assert_floateq(song.force_vector.attack, -1.621171);
     assert_eq(song.channels, 2);
 
     assert_eq(song.nSamples, 12508554);


### PR DESCRIPTION
reverts incorrect values set in d95acd0
(also fixes CI build)