### PR TITLE
Add first streaming tentative with aubio

### DIFF
--- a/bliss-rs/Cargo.toml
+++ b/bliss-rs/Cargo.toml
@@ -13,12 +13,10 @@ build-ffmpeg = ["ffmpeg4/build"]
 ripemd160 = "*"
 
 [dependencies.aubio-rs]
-git = "https://github.com/Polochon-street/aubio-rs"
-branch = "add-some-utils"
+git = "https://github.com/katyo/aubio-rs"
 
 [dependencies.aubio-lib]
-git = "https://github.com/Polochon-street/aubio-rs"
-branch = "add-some-utils"
+git = "https://github.com/katyo/aubio-rs"
 optional = true
 
 [dependencies.ffmpeg4]

--- a/bliss-rs/src/lib.rs
+++ b/bliss-rs/src/lib.rs
@@ -1,6 +1,7 @@
 // temporarily pub
 pub mod analyze;
 pub mod decode;
+pub mod utils;
 
 pub const CHANNELS: u16 = 1;
 pub const SAMPLE_RATE: u32 = 22050;

--- a/bliss-rs/src/utils.rs
+++ b/bliss-rs/src/utils.rs
@@ -1,0 +1,21 @@
+pub fn mean<T: Clone + Into<f32>>(input: &[T]) -> f32 {
+    input.iter().map(|x| x.clone().into() as f32).sum::<f32>() / input.len() as f32
+}
+
+pub fn number_crossings(input: &[f32]) -> usize {
+    let j: usize;
+    let mut ncr: usize = 0;
+
+    for j in 1..input.len() {
+        if input[j - 1] < 0. {
+            if input[j] >= 0. {
+                ncr += 1;
+            }
+        } else {
+            if input[j] < 0. {
+                ncr += 1;
+            }
+        }
+    }
+    ncr
+}


### PR DESCRIPTION
Trying to see if it's possible to have a `Descriptor` global class so we could have sth like
```
for chunk in chunks {
    descriptor1.do_(chunk);
    descriptor2.do_(chunk);
}
```
in order to only go through the sample array once